### PR TITLE
feat: Implement relics

### DIFF
--- a/src/components/gw2/character/consumables/Consumables.astro
+++ b/src/components/gw2/character/consumables/Consumables.astro
@@ -7,15 +7,17 @@ interface Props {
   foodId?: number;
   utilityId?: number;
   infusionId?: number;
+  relicId?: number;
   data?: {
     foodData?: GW2ApiItem;
     utilityData?: GW2ApiItem;
     infusionData?: GW2ApiItem;
+    relicData?: GW2ApiItem;
   };
 }
 
 const { data } = Astro.props;
-const { foodData, utilityData, infusionData } = data;
+const { foodData, utilityData, infusionData, relicData } = data;
 ---
 
 <div class="root">
@@ -67,6 +69,19 @@ const { foodData, utilityData, infusionData } = data;
       </div>
     )
   }
+    {
+      relicData && (
+        <div class="gridItem borderLeft">
+          <ItemInternal
+            dataItem={relicData}
+            className="gw2item"
+            disableText
+            client:visible
+          />
+          <span class="title">Relic</span>
+        </div>
+      )
+    }
 </div>
 
 <style>

--- a/src/utils/remark/remark-inject-data/index.js
+++ b/src/utils/remark/remark-inject-data/index.js
@@ -191,6 +191,7 @@ const COMPONENTS = [
             foodData: resolve(items)(parsed.consumables.foodId),
             utilityData: resolve(items)(parsed.consumables.utilityId),
             infusionData: resolve(items)(parsed.consumables.infusionId),
+            relicData: resolve(items)(parsed.consumables.relicId),
           };
 
           return {


### PR DESCRIPTION
Implements the display of relics in builds.

See https://github.com/discretize/discretize-ui/commit/2adc23898ebf07ac6906c3502b71259fe63e0cbc.

Not sure if this is complete (I don't understand the structure of this codebase really and I see a lot of things called "Character" when I search the repo).