### PR TITLE
chore: Update gear optimizer module

### DIFF
--- a/src/components/gw2/peepoptimizer/Peepoptimizer.tsx
+++ b/src/components/gw2/peepoptimizer/Peepoptimizer.tsx
@@ -4,7 +4,7 @@ import AffixSelect from "./AffixSelect";
 import ResultCharacter from "./ResultCharacter";
 import type { Character } from "discretize-gear-optimizer/src/state/optimizer/optimizerCore";
 
-const testState = {
+const testState: Parameters<typeof import('discretize-gear-optimizer/src/state/optimizer/optimizer').calculate>[0] = {
   optimizer: {
     userSettings: { expertMode: true, gameMode: "fractals" },
     control: {
@@ -25,6 +25,7 @@ const testState = {
       filterMode: "None",
       displayAttributes: [],
       progress: 0,
+      heuristicsProgress: undefined,
       selectedCharacter: null,
       selectedTemplate: "Condi Virtuoso Dueling",
       status: "WAITING",

--- a/src/components/gw2/peepoptimizer/ResultCharacter.tsx
+++ b/src/components/gw2/peepoptimizer/ResultCharacter.tsx
@@ -62,7 +62,7 @@ export default function ResultCharacter({
     Enhancement: utility,
     Nourishment: food,
     Runes: runeStringId,
-  } = extrasCombination || cachedFormState.extras; // fallback for builds from before extras refactor
+  } = extrasCombination || cachedFormState.extras as any as typeof extrasCombination; // fallback for builds from before extras refactor
 
   const foodId = allExtrasModifiersById[food]?.gw2id;
   const utilityId = allExtrasModifiersById[utility]?.gw2id;


### PR DESCRIPTION
This updates the gear optimizer submodule and syncs the in-page optimizer code to work with the current optimizer codebase.

Not updated to the latest commit because https://github.com/discretize/discretize-gear-optimizer/pull/818 is not currently compatible (it imports from react-redux and comlink). I'll have to fix that.